### PR TITLE
Analyse the code

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,8 @@ __date__ = "March 2017"
 
 from lane_updated import *
 from moviepy.editor import VideoFileClip
+import os
+import numpy as np
 
 
 if __name__ == "__main__":
@@ -14,7 +16,7 @@ if __name__ == "__main__":
     demo = 2 # 1: image, 2 video
 
     if demo == 1:
-        imagepath = 'examples/test12.jpg'
+        imagepath = 'examples/test11.jpg'
         img = cv2.imread(imagepath)
         img = cv2.resize(img, (1280, 720))  # Resize to 1280x720
 
@@ -31,9 +33,31 @@ if __name__ == "__main__":
         plt.show()
 
     else:
+        video_path = "examples/front_forward1.mp4"
         video_output = 'examples/front_forward1_test.mp4'
-        clip1 = VideoFileClip("examples/front_forward1.mp4")
 
-        clip = clip1.fl_image(process_frame) #NOTE: it should be in BGR format
-        clip.write_videofile(video_output, audio=False)
+        if not os.path.exists(video_path):
+            print(f"[INFO] Video not found at {video_path}. Falling back to single image demo.")
+            imagepath = 'examples/test11.jpg'
+            img = cv2.imread(imagepath)
+            img = cv2.resize(img, (1280, 720))
+            img_aug = process_frame(img)
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            img_aug = cv2.cvtColor(img_aug, cv2.COLOR_BGR2RGB)
+            plt.figure(figsize=(12,6))
+            plt.subplot(1,2,1); plt.imshow(img); plt.title('Original'); plt.axis('off')
+            plt.subplot(1,2,2); plt.imshow(img_aug); plt.title('Augmented'); plt.axis('off')
+            plt.savefig('output_debug.png')
+            plt.show()
+        else:
+            clip1 = VideoFileClip(video_path)
+
+            # MoviePy provides RGB frames; convert to BGR before processing, then back to RGB
+            def process_frame_rgb(frame_rgb):
+                frame_bgr = cv2.cvtColor(frame_rgb, cv2.COLOR_RGB2BGR)
+                out_bgr = process_frame(frame_bgr)
+                return cv2.cvtColor(out_bgr, cv2.COLOR_BGR2RGB)
+
+            clip = clip1.fl_image(process_frame_rgb)
+            clip.write_videofile(video_output, audio=False)
 


### PR DESCRIPTION
Harden lane detection to prevent crashes from empty pixel sets, fix MoviePy RGB/BGR handling, correct lane offset calculation, and improve overall robustness.

The `TypeError: expected non-empty vector for x` occurred because `np.polyfit` was called with empty arrays when no lane pixels were detected. This PR adds checks to handle such cases gracefully by returning `None` and allowing the `Lane` objects to revert to previous valid fits or return the undistorted frame. Additionally, the MoviePy video processing was failing due to an RGB/BGR color space mismatch, and the calibration file path was incorrect, both of which are now resolved.

---
<a href="https://cursor.com/background-agent?bcId=bc-357055df-cf27-4ab1-9fae-d857db1748c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-357055df-cf27-4ab1-9fae-d857db1748c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

